### PR TITLE
Add running a windows 10 app locally example to documentation.

### DIFF
--- a/app/templates/documentation.hbs
+++ b/app/templates/documentation.hbs
@@ -145,6 +145,18 @@
 				<span class="app">http://meteorite.azurewebsites.net -d C:\Projects -l info -p windows,android -b</span>
 			</p>
 		</div></p>
+		<h4>Running a Windows 10 app locally</h4>
+			<p><div class="shell">
+			<p class="line">
+				<span class="prompt">$</span>
+				<span class="app">cd /path/to/myapp</span>
+			</p>
+			<p class="line">
+				<span class="prompt">$</span>
+				<span class="command">manifoldjs </span>
+				<span class="app">run windows</span>
+			</p>
+			</div></p>
 		<h4>Packaging a Windows 10 app for submission to the Store</h4>
         <p><div class="shell">
 			<p class="line">


### PR DESCRIPTION
Myself and a few others from the Microsoft Edge team spent a couple days last week creating a Hosted Windows App and packaging it with ManifoldJS. 

ManifoldJS is a great tool to help us accomplish this, but we felt that in the example commands the `manifoldjs run ...` command should be called out in the example documentation. It's an immensely helpful command for debugging locally and we ran into MANY issues trying to replicate that command manually before realizing that ManifoldJS did that magic for us.